### PR TITLE
docs: add project summary and module map to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# e-GroceryWeb
+
+## Project summary
+`e-GroceryWeb` is a Spring Boot 2.7 + JSP web application for an online grocery platform. The project already includes user-facing storefront screens, login/registration flows, and a separate admin dashboard UI with pages for categories, products, orders, payments, and blogs.
+
+The codebase currently looks like a UI-first foundation:
+- JSP views are present for major user and admin modules.
+- Static resources (CSS/JS/images) are already organized for both user and admin themes.
+- Controller coverage is still minimal, with only a root login mapping currently wired.
+
+## Tech stack
+- Java 8
+- Spring Boot 2.7.18
+- Spring MVC + JSP/JSTL (`tomcat-embed-jasper`, `jstl`)
+- Spring Data JPA dependency included
+- MySQL connector included (runtime)
+
+## Current app behavior
+- The app starts from `EGroceryWebApplication`.
+- The root route (`/`) maps to the login page JSP: `LoginAndRegister/Login`.
+- Server port is configured as `8081`.
+
+## High-level module layout
+- `src/main/java/com/nt`: Spring Boot entry point and controllers.
+- `src/main/webapp/WEB-INF/jsp/LoginAndRegister`: authentication and role-selection screens.
+- `src/main/webapp/WEB-INF/jsp/UserModel`: storefront pages (home, shop, product detail, cart/order/payment/profile, blog, contact, about).
+- `src/main/webapp/WEB-INF/jsp/AdminModel`: dashboard plus management screens for categories/products/orders/payments/blogs/profile.
+- `src/main/webapp/resources`: static assets for Login/Register, UserModel, and AdminModel interfaces.
+
+## Notes
+- Data source auto-configuration is currently excluded in the application bootstrap class, so DB-backed features may still be under active development.
+- This repository is a good base for continuing with full controller/service/repository wiring for production-ready workflows.


### PR DESCRIPTION
### Motivation
- Provide a concise project overview, tech stack, module layout and current development notes to help contributors understand the repository and next steps.

### Description
- Added a detailed `README.md` containing the project summary, tech stack, current app behavior, high-level module layout and notes about datasource auto-configuration being excluded.

### Testing
- Ran `mvn test -q`, which failed because Maven Central returned `403 Forbidden` while resolving `org.springframework.boot:spring-boot-starter-parent:2.7.18`, so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698422d4b97c8328933a647f85a5ea75)